### PR TITLE
Update Name tagging

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -6,7 +6,7 @@ resource "aws_vpc_endpoint" "service_consumer" {
   vpc_endpoint_type  = "Interface"
 
   tags = {
-    Name             = "${var.service_name}"
+    Name             = "${var.service_name}-vpce"
     Description      = "${var.description}"
     Environment      = "${var.environment}"
     ProductDomain    = "${var.product_domain}"


### PR DESCRIPTION
I have discussion with Febri that for consumer `Name` tag will using suffix `-vpce` and for provider `Name` tag will using suffix `-vpces`.
`vpce` means VPC endpoint.
`vpces` means VPC endpoint service.