### PR TITLE
fixing warning when trying to apply with tf12

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -46,7 +46,7 @@ variable "private_dns_enabled" {
 }
 
 variable "additional_tags" {
-  type        = "map"
+  type        = map
   description = "Additional tags to be added to the VPC Endpoint"
   default     = {}
 }


### PR DESCRIPTION
This PR will fix this warning when trying to apply with terraform `0.12.x`
```
Warning: Quoted type constraints are deprecated

  on .terraform/modules/vpce/variables.tf line 49, in variable "additional_tags":
  49:   type        = "map"

Terraform 0.11 and earlier required type constraints to be given in quotes,
but that form is now deprecated and will be removed in a future version of
Terraform. To silence this warning, remove the quotes around "map" and write
map(string) instead to explicitly indicate that the map elements are strings.
```